### PR TITLE
feat: Feature Zero integration test (#2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,13 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "pytest-asyncio>=1.0.0",
 ]
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
 pythonpath = ["."]
+markers = [
+    "integration: end-to-end tests requiring API credentials",
+]
+asyncio_mode = "auto"

--- a/test/test_feature_zero.py
+++ b/test/test_feature_zero.py
@@ -1,0 +1,61 @@
+# test/test_feature_zero.py
+#
+# Integration test: validates the orchestrator agent responds end-to-end.
+# Requires GOOGLE_API_KEY in .env — skipped if not set.
+
+import os
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def api_key():
+    key = os.environ.get("GOOGLE_API_KEY", "")
+    if not key:
+        pytest.skip("GOOGLE_API_KEY not set — skipping integration test")
+    return key
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_responds_to_query(api_key):
+    """Send a wildfire risk query and verify the agent returns a non-empty response."""
+    from google.adk.runners import Runner
+    from google.adk.sessions import InMemorySessionService
+    from google.genai import types
+
+    from agents.orchestrator.agent import root_agent
+
+    session_service = InMemorySessionService()
+    runner = Runner(
+        agent=root_agent,
+        app_name="fireshield_test",
+        session_service=session_service,
+    )
+
+    session = await session_service.create_session(
+        app_name="fireshield_test", user_id="test_user"
+    )
+
+    message = types.Content(
+        role="user",
+        parts=[types.Part(text="Assess wildfire risk for a home in Tampa, FL")],
+    )
+
+    response_texts = []
+    async for event in runner.run_async(
+        user_id="test_user",
+        session_id=session.id,
+        new_message=message,
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    response_texts.append(part.text)
+
+    full_response = " ".join(response_texts)
+    assert len(full_response) > 0, "Agent returned empty response"
+    assert any(
+        word in full_response.lower()
+        for word in ["wildfire", "fire", "risk", "tampa", "florida"]
+    ), f"Response doesn't mention wildfire/risk topics: {full_response[:200]}"


### PR DESCRIPTION
## Plan

See `docs/plans/2026-03-24-2330-feature-zero.md`

## Summary

- Adds `test/test_feature_zero.py` — integration test that sends a wildfire risk query to the orchestrator agent via ADK Runner and validates a meaningful response
- Adds `pytest-asyncio` dependency and `integration` marker to `pyproject.toml`
- Test gracefully skips when `GOOGLE_API_KEY` is not set

## Remaining for #2

- `.env` setup with API key (user action)
- Manual `adk web` verification (user action)

These are user-side tasks that can't be automated in a PR.

## Test plan

- [x] `uv run pytest test/test_smoke.py` — 8/8 pass
- [x] `uv run pytest test/test_feature_zero.py` — skips without API key
- [ ] `uv run pytest test/test_feature_zero.py -m integration` — passes with API key

Closes #2